### PR TITLE
OptionsResolver: add nullable date/time normalizers

### DIFF
--- a/src/Pohoda/Common/OptionsResolver.php
+++ b/src/Pohoda/Common/OptionsResolver.php
@@ -73,6 +73,7 @@ class OptionsResolver extends SymfonyOptionsResolver
             case 'datetimeOrNull':
             case 'timeOrNull':
                 $nullable = true;
+                // no break
             case 'date':
             case 'datetime':
             case 'time':

--- a/src/Pohoda/Common/OptionsResolver.php
+++ b/src/Pohoda/Common/OptionsResolver.php
@@ -69,12 +69,21 @@ class OptionsResolver extends SymfonyOptionsResolver
                     return \mb_substr($value, 0, $param, 'utf-8');
                 };
 
+            case 'dateOrNull':
+            case 'datetimeOrNull':
+            case 'timeOrNull':
+                $nullable = true;
             case 'date':
             case 'datetime':
             case 'time':
                 $format = static::DATE_FORMATS[$type];
+                $nullable = $nullable ?? false;
 
-                return function ($options, $value) use ($format) {
+                return function ($options, $value) use ($format, $nullable) {
+                    if ($nullable && empty($value)) {
+                        return '';
+                    }
+                    
                     if ($value instanceof \DateTimeInterface) {
                         return $value->format($format);
                     }

--- a/src/Pohoda/Common/OptionsResolver.php
+++ b/src/Pohoda/Common/OptionsResolver.php
@@ -84,7 +84,7 @@ class OptionsResolver extends SymfonyOptionsResolver
                     if ($nullable && empty($value)) {
                         return '';
                     }
-                    
+
                     if ($value instanceof \DateTimeInterface) {
                         return $value->format($format);
                     }


### PR DESCRIPTION
I just came across `dateOrNull` type in spec, so I added it here together with datetime & time variants. Not sure about the implementation and naming consistency (null vs empty string, but this is how Pohoda spec states actually)