### PR TITLE
Pass encoding to the open method

### DIFF
--- a/src/Pohoda.php
+++ b/src/Pohoda.php
@@ -197,7 +197,7 @@ class Pohoda
     {
         $this->_xmlReader = new \XMLReader();
 
-        if (!$this->_xmlReader->open($filename)) {
+        if (!$this->_xmlReader->open($filename, self::$encoding)) {
             return false;
         }
 


### PR DESCRIPTION
This fixes the problem `parser error : Input is not proper UTF-8, indicate encoding !`