### PR TITLE
Add option "markRecord" for AddressBook

### DIFF
--- a/src/Pohoda/Addressbook/Header.php
+++ b/src/Pohoda/Addressbook/Header.php
@@ -23,7 +23,7 @@ class Header extends Agenda
     protected $_refElements = ['centre', 'activity', 'contract', 'number'];
 
     /** @var string[] */
-    protected $_elements = ['identity', 'region', 'phone', 'mobil', 'fax', 'email', 'web', 'ICQ', 'Skype', 'GPS', 'credit', 'priceIDS', 'maturity', 'paymentType', 'agreement', 'number', 'ost1', 'ost2', 'p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'message', 'note', 'intNote', 'centre', 'activity', 'contract'];
+    protected $_elements = ['identity', 'region', 'phone', 'mobil', 'fax', 'email', 'web', 'ICQ', 'Skype', 'GPS', 'credit', 'priceIDS', 'maturity', 'paymentType', 'agreement', 'number', 'ost1', 'ost2', 'p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'markRecord', 'message', 'note', 'intNote', 'centre', 'activity', 'contract'];
 
     /**
      * {@inheritdoc}
@@ -81,6 +81,7 @@ class Header extends Agenda
         $resolver->setNormalizer('p4', $resolver->getNormalizer('bool'));
         $resolver->setNormalizer('p5', $resolver->getNormalizer('bool'));
         $resolver->setNormalizer('p6', $resolver->getNormalizer('bool'));
+        $resolver->setNormalizer('markRecord', $resolver->getNormalizer('bool'));
         $resolver->setNormalizer('message', $resolver->getNormalizer('string64'));
     }
 }


### PR DESCRIPTION
I would like to add the `markRecord` option to AddressBook as per documentation below.

https://www.stormware.cz/schema/version_2/addressbook.xsd

```xml
<xsd:element name="markRecord" type="typ:boolean" minOccurs="0" default="true">
<xsd:annotation>
<xsd:documentation>Označení záznamu v programu POHODA, sloupec "X". Výchozí hodnota je "označený záznam".</xsd:documentation>
</xsd:annotation>
</xsd:element>
```