### PR TITLE
Add 'adGroup' to AddressBook header

### DIFF
--- a/src/Pohoda/Addressbook/Header.php
+++ b/src/Pohoda/Addressbook/Header.php
@@ -23,7 +23,7 @@ class Header extends Agenda
     protected $_refElements = ['centre', 'activity', 'contract', 'number'];
 
     /** @var string[] */
-    protected $_elements = ['identity', 'region', 'phone', 'mobil', 'fax', 'email', 'web', 'ICQ', 'Skype', 'GPS', 'credit', 'priceIDS', 'maturity', 'paymentType', 'agreement', 'number', 'ost1', 'ost2', 'p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'markRecord', 'message', 'note', 'intNote', 'centre', 'activity', 'contract'];
+    protected $_elements = ['identity', 'region', 'phone', 'mobil', 'fax', 'email', 'web', 'ICQ', 'Skype', 'GPS', 'credit', 'priceIDS', 'maturity', 'paymentType', 'agreement', 'number', 'ost1', 'ost2', 'p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'markRecord', 'message', 'note', 'intNote', 'centre', 'activity', 'contract', 'adGroup'];
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
Allow AddressBook header to enlist  'adGroup' element. This is allowed in [XSD](https://www.stormware.cz/xml/schema/version_2/addressbook.xsd)