### PR TITLE
[NAN-1120] Add field 'dateTaxOriginalDocumentMOSS' to Invoice

### DIFF
--- a/src/Pohoda/Invoice/Header.php
+++ b/src/Pohoda/Invoice/Header.php
@@ -19,7 +19,7 @@ class Header extends DocumentHeader
     protected $_refElements = ['extId', 'number', 'accounting', 'classificationVAT', 'classificationKVDPH', 'order', 'paymentType', 'priceLevel', 'account', 'paymentAccount', 'centre', 'activity', 'contract', 'regVATinEU', 'MOSS', 'evidentiaryResourcesMOSS', 'carrier'];
 
     /** @var string[] */
-    protected $_elements = ['extId', 'invoiceType', 'number', 'symVar', 'originalDocument', 'originalDocumentNumber', 'symPar', 'date', 'dateTax', 'dateAccounting', 'dateKHDPH', 'dateDue', 'dateApplicationVAT', 'dateDelivery', 'accounting', 'classificationVAT', 'classificationKVDPH', 'numberKHDPH', 'text', 'partnerIdentity', 'myIdentity', 'order', 'numberOrder', 'dateOrder', 'paymentType', 'priceLevel', 'account', 'symConst', 'symSpec', 'paymentAccount', 'paymentTerminal', 'centre', 'activity', 'contract', 'regVATinEU', 'MOSS', 'evidentiaryResourcesMOSS', 'accountingPeriodMOSS', 'note', 'carrier', 'intNote'];
+    protected $_elements = ['extId', 'invoiceType', 'number', 'symVar', 'originalDocument', 'originalDocumentNumber', 'symPar', 'date', 'dateTax', 'dateAccounting', 'dateKHDPH', 'dateDue', 'dateApplicationVAT', 'dateDelivery', 'accounting', 'classificationVAT', 'classificationKVDPH', 'numberKHDPH', 'text', 'partnerIdentity', 'myIdentity', 'order', 'numberOrder', 'dateOrder', 'paymentType', 'priceLevel', 'account', 'symConst', 'symSpec', 'paymentAccount', 'paymentTerminal', 'centre', 'activity', 'contract', 'regVATinEU', 'MOSS', 'evidentiaryResourcesMOSS', 'accountingPeriodMOSS', 'dateTaxOriginalDocumentMOSS', 'note', 'carrier', 'intNote'];
 
     /**
      * {@inheritdoc}
@@ -48,5 +48,6 @@ class Header extends DocumentHeader
         $resolver->setNormalizer('symConst', $resolver->getNormalizer('string4'));
         $resolver->setNormalizer('symSpec', $resolver->getNormalizer('string16'));
         $resolver->setNormalizer('paymentTerminal', $resolver->getNormalizer('bool'));
+        $resolver->setNormalizer('dateTaxOriginalDocumentMOSS', $resolver->getNormalizer('date'));
     }
 }


### PR DESCRIPTION
Hello,

I added the field `dateTaxOriginalDocumentMOSS` (Datum Zdanitelného plnění původního dokladu) to the Invoice Header class, so that it can be used when generating XML for issuedCorrectiveTax document (Opravný doklad). 

This field was mandatory for our usecase where we generate Corrective Tax document for warranty claims  on the fly with link to the original invoice.