### PR TITLE
Several small tweaks 

### DIFF
--- a/src/Pohoda/Document.php
+++ b/src/Pohoda/Document.php
@@ -39,9 +39,9 @@ abstract class Document extends Agenda
      *
      * @param array<string,mixed> $data
      *
-     * @return $this
+     * @return Riesenia\Pohoda\Document\Part
      */
-    public function addItem(array $data): self
+    public function addItem(array $data): Part
     {
         $key = $this->_getDocumentName() . 'Detail';
 
@@ -49,9 +49,10 @@ abstract class Document extends Agenda
             $this->_data[$key] = [];
         }
 
-        $this->_data[$key][] = $this->_getDocumentPart('Item', $data, $this->_ico);
+        $part = $this->_getDocumentPart('Item', $data, $this->_ico);
+        $this->_data[$key][] = $part;
 
-        return $this;
+        return $part;
     }
 
     /**

--- a/src/Pohoda/Document/Item.php
+++ b/src/Pohoda/Document/Item.php
@@ -13,9 +13,12 @@ namespace Riesenia\Pohoda\Document;
 use Riesenia\Pohoda\Common\OptionsResolver;
 use Riesenia\Pohoda\Type\CurrencyItem;
 use Riesenia\Pohoda\Type\StockItem;
+use Riesenia\Pohoda\Common\AddParameterTrait;
 
 abstract class Item extends Part
 {
+    use AddParameterTrait;
+
     /**
      * {@inheritdoc}
      */

--- a/src/Pohoda/Invoice/Header.php
+++ b/src/Pohoda/Invoice/Header.php
@@ -19,7 +19,7 @@ class Header extends DocumentHeader
     protected $_refElements = ['extId', 'number', 'accounting', 'classificationVAT', 'classificationKVDPH', 'order', 'paymentType', 'priceLevel', 'account', 'paymentAccount', 'centre', 'activity', 'contract', 'regVATinEU', 'MOSS', 'evidentiaryResourcesMOSS', 'carrier'];
 
     /** @var string[] */
-    protected $_elements = ['extId', 'invoiceType', 'number', 'symVar', 'originalDocument', 'originalDocumentNumber', 'symPar', 'date', 'dateTax', 'dateAccounting', 'dateKHDPH', 'dateDue', 'dateApplicationVAT', 'dateDelivery', 'accounting', 'classificationVAT', 'classificationKVDPH', 'numberKHDPH', 'text', 'partnerIdentity', 'myIdentity', 'order', 'numberOrder', 'dateOrder', 'paymentType', 'priceLevel', 'account', 'symConst', 'symSpec', 'paymentAccount', 'paymentTerminal', 'centre', 'activity', 'contract', 'regVATinEU', 'MOSS', 'evidentiaryResourcesMOSS', 'accountingPeriodMOSS', 'note', 'carrier', 'intNote'];
+    protected $_elements = ['extId', 'invoiceType', 'number', 'symVar', 'originalDocument', 'originalDocumentNumber', 'symPar', 'date', 'dateTax', 'dateAccounting', 'dateKHDPH', 'dateDue', 'dateApplicationVAT', 'dateDelivery', 'accounting', 'classificationVAT', 'classificationKVDPH', 'numberKHDPH', 'text', 'partnerIdentity', 'myIdentity', 'order', 'numberOrder', 'dateOrder', 'paymentType', 'priceLevel', 'account', 'symConst', 'symSpec', 'paymentAccount', 'paymentTerminal', 'centre', 'activity', 'contract', 'regVATinEU', 'MOSS', 'evidentiaryResourcesMOSS', 'accountingPeriodMOSS', 'dateTaxOriginalDocumentMOSS', 'note', 'carrier', 'intNote'];
 
     /**
      * {@inheritdoc}
@@ -48,5 +48,6 @@ class Header extends DocumentHeader
         $resolver->setNormalizer('symConst', $resolver->getNormalizer('string4'));
         $resolver->setNormalizer('symSpec', $resolver->getNormalizer('string16'));
         $resolver->setNormalizer('paymentTerminal', $resolver->getNormalizer('bool'));
+        $resolver->setNormalizer('dateTaxOriginalDocumentMOSS', $resolver->getNormalizer('date'));
     }
 }

--- a/src/Pohoda/IssueSlip/Header.php
+++ b/src/Pohoda/IssueSlip/Header.php
@@ -19,7 +19,7 @@ class Header extends DocumentHeader
     protected $_refElements = ['number', 'priceLevel', 'paymentType', 'centre', 'activity', 'contract', 'carrier', 'regVATinEU', 'MOSS', 'evidentiaryResourcesMOSS'];
 
     /** @var string[] */
-    protected $_elements = ['number', 'date', 'numberOrder', 'dateOrder', 'text', 'partnerIdentity', 'acc', 'symPar', 'priceLevel', 'paymentType', 'isExecuted', 'isDelivered', 'centre', 'activity', 'contract', 'carrier', 'regVATinEU', 'MOSS', 'evidentiaryResourcesMOSS', 'accountingPeriodMOSS', 'note', 'intNote'];
+    protected $_elements = ['number', 'date', 'numberOrder', 'dateOrder', 'text', 'partnerIdentity', 'acc', 'symPar', 'priceLevel', 'paymentType', 'isExecuted', 'isDelivered', 'centre', 'activity', 'contract', 'carrier', 'regVATinEU', 'MOSS', 'evidentiaryResourcesMOSS', 'accountingPeriodMOSS', 'note', 'intNote', 'histRate'];
 
     /**
      * {@inheritdoc}
@@ -37,5 +37,6 @@ class Header extends DocumentHeader
         $resolver->setNormalizer('symPar', $resolver->getNormalizer('string20'));
         $resolver->setNormalizer('isExecuted', $resolver->getNormalizer('bool'));
         $resolver->setNormalizer('isDelivered', $resolver->getNormalizer('bool'));
+        $resolver->setNormalizer('histRate', $resolver->getNormalizer('bool'));
     }
 }

--- a/src/Pohoda/IssueSlip/Item.php
+++ b/src/Pohoda/IssueSlip/Item.php
@@ -19,7 +19,7 @@ class Item extends DocumentItem
     protected $_refElements = ['typeServiceMOSS', 'centre', 'activity', 'contract'];
 
     /** @var string[] */
-    protected $_elements = ['text', 'quantity', 'unit', 'coefficient', 'payVAT', 'rateVAT', 'discountPercentage', 'homeCurrency', 'foreignCurrency', 'typeServiceMOSS', 'note', 'code', 'stockItem', 'centre', 'activity', 'contract'];
+    protected $_elements = ['text', 'quantity', 'unit', 'coefficient', 'payVAT', 'rateVAT', 'percentVAT', 'discountPercentage', 'homeCurrency', 'foreignCurrency', 'typeServiceMOSS', 'note', 'code', 'stockItem', 'centre', 'activity', 'contract'];
 
     /**
      * {@inheritdoc}
@@ -34,7 +34,8 @@ class Item extends DocumentItem
         $resolver->setNormalizer('unit', $resolver->getNormalizer('string10'));
         $resolver->setNormalizer('coefficient', $resolver->getNormalizer('float'));
         $resolver->setNormalizer('payVAT', $resolver->getNormalizer('bool'));
-        $resolver->setAllowedValues('rateVAT', ['none', 'third', 'low', 'high']);
+        $resolver->setAllowedValues('rateVAT', ['none', 'high', 'low', 'third', 'historyHigh', 'historyLow', 'historyThird']);
+        $resolver->setNormalizer('percentVAT', $resolver->getNormalizer('int'));
         $resolver->setNormalizer('discountPercentage', $resolver->getNormalizer('float'));
         $resolver->setNormalizer('note', $resolver->getNormalizer('string90'));
         $resolver->setNormalizer('code', $resolver->getNormalizer('string64'));

--- a/src/Pohoda/Order/Header.php
+++ b/src/Pohoda/Order/Header.php
@@ -19,7 +19,7 @@ class Header extends DocumentHeader
     protected $_refElements = ['extId', 'number', 'paymentType', 'priceLevel', 'centre', 'activity', 'contract', 'regVATinEU', 'MOSS', 'evidentiaryResourcesMOSS', 'carrier'];
 
     /** @var string[] */
-    protected $_elements = ['extId', 'orderType', 'number', 'numberOrder', 'date', 'dateDelivery', 'dateFrom', 'dateTo', 'text', 'partnerIdentity', 'myIdentity', 'paymentType', 'priceLevel', 'isExecuted', 'isReserved', 'centre', 'activity', 'contract', 'regVATinEU', 'MOSS', 'evidentiaryResourcesMOSS', 'accountingPeriodMOSS', 'note', 'carrier', 'intNote', 'markRecord'];
+    protected $_elements = ['extId', 'orderType', 'number', 'numberOrder', 'date', 'dateDelivery', 'dateFrom', 'dateTo', 'text', 'partnerIdentity', 'myIdentity', 'paymentType', 'priceLevel', 'isExecuted', 'isReserved', 'centre', 'activity', 'contract', 'regVATinEU', 'MOSS', 'evidentiaryResourcesMOSS', 'accountingPeriodMOSS', 'note', 'carrier', 'intNote', 'markRecord', 'histRate'];
 
     /**
      * {@inheritdoc}
@@ -40,5 +40,6 @@ class Header extends DocumentHeader
         $resolver->setNormalizer('isExecuted', $resolver->getNormalizer('bool'));
         $resolver->setNormalizer('isReserved', $resolver->getNormalizer('bool'));
         $resolver->setNormalizer('markRecord', $resolver->getNormalizer('bool'));
+        $resolver->setNormalizer('histRate', $resolver->getNormalizer('bool'));
     }
 }


### PR DESCRIPTION
**Allow parameters (custom fields) for items**

Parameters (Custom fields) for items is used in our project, therefore I added the possiblity to add these to document items. I hope it won't be against your way of using this lib, but honestly the change is very subtle. I allowed the item to return Riesenia\Pohoda\Document\Part instead of $this and added use AddParameterTrait.

**Other minor tweaks**
- Allow histRate field for Orders
- Allow percentVAT field for IssueSlip + allowed rateVAT values
- Allow histRate field for IssueSlip