### PR TITLE
Added support for queryFilter (SQL) in ListRequest and PrintRequest

### DIFF
--- a/spec/Pohoda/ListRequestSpec.php
+++ b/spec/Pohoda/ListRequestSpec.php
@@ -105,6 +105,18 @@ class ListRequestSpec extends ObjectBehavior
         $this->addUserFilterName('CustomFilter')->getXML()->asXML()->shouldReturn('<lst:listInvoiceRequest version="2.0" invoiceVersion="2.0" invoiceType="issuedInvoice"><lst:requestInvoice><ftr:userFilterName>CustomFilter</ftr:userFilterName></lst:requestInvoice></lst:listInvoiceRequest>');
     }
 
+    public function it_creates_correct_xml_for_invoice_with_query_filter()
+    {
+        $this->beConstructedWith([
+            'type' => 'Invoice'
+        ], '123');
+
+        $this->addQueryFilter([
+            'filter' => '(FA.DatSave>=CONVERT(DATETIME, \'01/31/2025 16:30:00\', 101) OR FA.DatLikv>=CONVERT(DATETIME, \'01/31/2025\', 101))',
+            'textName' => '(Uloženo >= 2025-01-31 16:30:00; Likv. >= 2025-01-31)',
+        ])->getXML()->asXML()->shouldReturn('<lst:listInvoiceRequest version="2.0" invoiceVersion="2.0" invoiceType="issuedInvoice"><lst:requestInvoice><ftr:queryFilter><ftr:filter>(FA.DatSave&gt;=CONVERT(DATETIME, \'01/31/2025 16:30:00\', 101) OR FA.DatLikv&gt;=CONVERT(DATETIME, \'01/31/2025\', 101))</ftr:filter><ftr:textName>(Uloženo &gt;= 2025-01-31 16:30:00; Likv. &gt;= 2025-01-31)</ftr:textName></ftr:queryFilter></lst:requestInvoice></lst:listInvoiceRequest>');
+    }
+
     public function it_creates_correct_xml_for_stock_with_complex_filter()
     {
         $this->beConstructedWith([

--- a/src/Pohoda/Filter/QueryFilter.php
+++ b/src/Pohoda/Filter/QueryFilter.php
@@ -39,7 +39,8 @@ class QueryFilter extends Agenda
         $resolver->setDefined($this->_elements);
 
         // validate / format options
-        $resolver->setNormalizer('filter', $resolver->getNormalizer('string'));
+        $resolver->setRequired('filter');
+        $resolver->setNormalizer('filter', $resolver->getNormalizer('string255'));
         $resolver->setNormalizer('textName', $resolver->getNormalizer('string200'));
     }
 }

--- a/src/Pohoda/Filter/QueryFilter.php
+++ b/src/Pohoda/Filter/QueryFilter.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This file is part of riesenia/pohoda package.
+ *
+ * Licensed under the MIT License
+ * (c) RIESENIA.com
+ */
+
+declare(strict_types=1);
+
+namespace Riesenia\Pohoda\Filter;
+
+use Riesenia\Pohoda\Agenda;
+use Riesenia\Pohoda\Common\OptionsResolver;
+
+class QueryFilter extends Agenda
+{
+    /** @var string[] */
+    protected $_elements = ['filter', 'textName'];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getXML(): \SimpleXMLElement
+    {
+        $xml = $this->_createXML()->addChild('ftr:queryFilter', '', $this->_namespace('ftr'));
+
+        $this->_addElements($xml, $this->_elements, 'ftr');
+
+        return $xml;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function _configureOptions(OptionsResolver $resolver)
+    {
+        // available options
+        $resolver->setDefined($this->_elements);
+
+        // validate / format options
+        $resolver->setNormalizer('filter', $resolver->getNormalizer('string'));
+        $resolver->setNormalizer('textName', $resolver->getNormalizer('string200'));
+    }
+}

--- a/src/Pohoda/ListRequest.php
+++ b/src/Pohoda/ListRequest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace Riesenia\Pohoda;
 
 use Riesenia\Pohoda\Common\OptionsResolver;
+use Riesenia\Pohoda\Filter\QueryFilter;
 use Riesenia\Pohoda\ListRequest\Filter;
 use Riesenia\Pohoda\ListRequest\RestrictionData;
 use Riesenia\Pohoda\ListRequest\UserFilterName;
@@ -28,6 +29,20 @@ class ListRequest extends Agenda
     public function addFilter(array $data): self
     {
         $this->_data['filter'] = new Filter($data, $this->_ico);
+
+        return $this;
+    }
+
+    /**
+     * Add query filter (SQL).
+     *
+     * @param array<string,mixed> $data
+     *
+     * @return $this
+     */
+    public function addQueryFilter(array $data): self
+    {
+        $this->_data['queryFilter'] = new QueryFilter($data, $this->_ico);
 
         return $this;
     }
@@ -89,7 +104,7 @@ class ListRequest extends Agenda
                 $this->_addElements($xml, ['restrictionData'], 'lst');
             }
 
-            $this->_addElements($request, ['filter', 'userFilterName'], 'ftr');
+            $this->_addElements($request, ['filter', 'queryFilter', 'userFilterName'], 'ftr');
         }
 
         return $xml;

--- a/src/Pohoda/PrintRequest/Record.php
+++ b/src/Pohoda/PrintRequest/Record.php
@@ -22,10 +22,14 @@ class Record extends Agenda
     public function __construct(array $data, string $ico, bool $resolveOptions = true)
     {
         // process filter
-        $data['filter'] = new Filter($data['filter'], $ico, $resolveOptions);
+        if (isset($data['filter'])) {
+            $data['filter'] = new Filter($data['filter'], $ico, $resolveOptions);
+        }
 
         // process query filter (SQL)
-        $data['queryFilter'] = new QueryFilter($data['queryFilter'], $ico, $resolveOptions);
+        if (isset($data['queryFilter'])) {
+            $data['queryFilter'] = new QueryFilter($data['queryFilter'], $ico, $resolveOptions);
+        }
 
         parent::__construct($data, $ico, $resolveOptions);
     }
@@ -52,6 +56,5 @@ class Record extends Agenda
         $resolver->setDefined(['agenda', 'filter', 'queryFilter']);
 
         $resolver->setRequired('agenda');
-        $resolver->setRequired('filter');
     }
 }

--- a/src/Pohoda/PrintRequest/Record.php
+++ b/src/Pohoda/PrintRequest/Record.php
@@ -12,6 +12,7 @@ namespace Riesenia\Pohoda\PrintRequest;
 
 use Riesenia\Pohoda\Agenda;
 use Riesenia\Pohoda\Common\OptionsResolver;
+use Riesenia\Pohoda\Filter\QueryFilter;
 
 class Record extends Agenda
 {
@@ -22,6 +23,9 @@ class Record extends Agenda
     {
         // process filter
         $data['filter'] = new Filter($data['filter'], $ico, $resolveOptions);
+
+        // process query filter (SQL)
+        $data['queryFilter'] = new QueryFilter($data['queryFilter'], $ico, $resolveOptions);
 
         parent::__construct($data, $ico, $resolveOptions);
     }
@@ -34,7 +38,7 @@ class Record extends Agenda
         $xml = $this->_createXML()->addChild('prn:record', '', $this->_namespace('prn'));
         $xml->addAttribute('agenda', $this->_data['agenda']);
 
-        $this->_addElements($xml, ['filter'], 'prn');
+        $this->_addElements($xml, ['filter', 'queryFilter'], 'prn');
 
         return $xml;
     }
@@ -45,7 +49,7 @@ class Record extends Agenda
     protected function _configureOptions(OptionsResolver $resolver)
     {
         // available options
-        $resolver->setDefined(['agenda', 'filter']);
+        $resolver->setDefined(['agenda', 'filter', 'queryFilter']);
 
         $resolver->setRequired('agenda');
         $resolver->setRequired('filter');


### PR DESCRIPTION
The change allows to use queryFilter in ListRequest and PrintRequest.

Example:
```
// Create list request for invoices
$request = $pohoda->createListRequest([
    'type' => 'Invoice',
    'invoiceType' => 'issuedInvoice',
]);

// Add filter for last changes
$request->addQueryFilter([
    'textName' => '(Uloženo >= 2025-01-31 16:30:00; Likv. >= 2025-01-31)',
    'filter' => "(FA.DatSave>=CONVERT(DATETIME, '01/31/2025 16:30:00', 101) OR FA.DatLikv>=CONVERT(DATETIME, '01/31/2025', 101))",
]);
```


```
<dat:dataPackItem version="2.0" id="list_001">
    <lst:listInvoiceRequest version="2.0" invoiceType="issuedInvoice" invoiceVersion="2.0">
        <lst:requestInvoice>
            <ftr:queryFilter>
                <ftr:filter>(FA.DatSave>=CONVERT(DATETIME, '01/31/2025 16:30:00', 101) OR FA.DatLikv>=CONVERT(DATETIME, '01/31/2025', 101))</ftr:filter>
                <ftr:textName>(Uloženo >= 2025-01-31 16:30:00; Likv. >= 2025-01-31)</ftr:textName>
            </ftr:queryFilter>
        </lst:requestInvoice>
    </lst:listInvoiceRequest>
</dat:dataPackItem>
```