### PR TITLE
PrintRequest - add support for PDF export as binary data and optional ISDOC embedding

### DIFF
--- a/spec/Pohoda/PrintRequestSpec.php
+++ b/spec/Pohoda/PrintRequestSpec.php
@@ -28,7 +28,15 @@ class PrintRequestSpec extends ObjectBehavior
                     'id' => 5678
                 ],
                 'pdf' => [
-                    'fileName' => 'C:\Test\1234.pdf'
+                    'fileName' => 'C:\Test\1234.pdf',
+                    'binaryData' => [
+                        'responseXml' => true,
+                        'removeFile' => true
+                    ],
+                    'isdoc' => [
+                        'includeToPdf' => true,
+                        'graphicNote' => 'topRight'
+                    ]
                 ]
             ]
         ], '123');
@@ -42,6 +50,6 @@ class PrintRequestSpec extends ObjectBehavior
 
     public function it_creates_correct_xml()
     {
-        $this->getXML()->asXML()->shouldReturn('<prn:print version="1.0"><prn:record agenda="vydane_faktury"><ftr:filter><ftr:id>1234</ftr:id></ftr:filter></prn:record><prn:printerSettings><prn:report><prn:id>5678</prn:id></prn:report><prn:pdf><prn:fileName>C:\Test\1234.pdf</prn:fileName></prn:pdf></prn:printerSettings></prn:print>');
+        $this->getXML()->asXML()->shouldReturn('<prn:print version="1.0"><prn:record agenda="vydane_faktury"><ftr:filter><ftr:id>1234</ftr:id></ftr:filter></prn:record><prn:printerSettings><prn:report><prn:id>5678</prn:id></prn:report><prn:pdf><prn:fileName>C:\Test\1234.pdf</prn:fileName><prn:binaryData><prn:responseXml>true</prn:responseXml><prn:removeFile>true</prn:removeFile></prn:binaryData><prn:isdoc><prn:includeToPdf>true</prn:includeToPdf><prn:graphicNote>topRight</prn:graphicNote></prn:isdoc></prn:pdf></prn:printerSettings></prn:print>');
     }
 }

--- a/src/Pohoda/PrintRequest/BinaryData.php
+++ b/src/Pohoda/PrintRequest/BinaryData.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This file is part of riesenia/pohoda package.
+ *
+ * Licensed under the MIT License
+ * (c) RIESENIA.com
+ */
+
+declare(strict_types=1);
+
+namespace Riesenia\Pohoda\PrintRequest;
+
+use Riesenia\Pohoda\Agenda;
+use Riesenia\Pohoda\Common\OptionsResolver;
+
+class BinaryData extends Agenda
+{
+    /** @var string[] */
+    protected $_elements = ['responseXml', 'removeFile'];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getXML(): \SimpleXMLElement
+    {
+        $xml = $this->_createXML()->addChild('prn:binaryData', '', $this->_namespace('prn'));
+
+        $this->_addElements($xml, $this->_elements, 'prn');
+
+        return $xml;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function _configureOptions(OptionsResolver $resolver)
+    {
+        // available options
+        $resolver->setDefined($this->_elements);
+
+        // validate / format options
+        $resolver->setRequired('responseXml');
+    }
+}

--- a/src/Pohoda/PrintRequest/BinaryData.php
+++ b/src/Pohoda/PrintRequest/BinaryData.php
@@ -40,5 +40,8 @@ class BinaryData extends Agenda
 
         // validate / format options
         $resolver->setRequired('responseXml');
+
+        $resolver->setNormalizer('responseXml', $resolver->getNormalizer('bool'));
+        $resolver->setNormalizer('removeFile', $resolver->getNormalizer('bool'));
     }
 }

--- a/src/Pohoda/PrintRequest/Isdoc.php
+++ b/src/Pohoda/PrintRequest/Isdoc.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * This file is part of riesenia/pohoda package.
+ *
+ * Licensed under the MIT License
+ * (c) RIESENIA.com
+ */
+
+declare(strict_types=1);
+
+namespace Riesenia\Pohoda\PrintRequest;
+
+use Riesenia\Pohoda\Agenda;
+use Riesenia\Pohoda\Common\OptionsResolver;
+
+class Isdoc extends Agenda
+{
+    /** @var string[] */
+    protected $_elements = ['includeToPdf', 'graphicNote'];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getXML(): \SimpleXMLElement
+    {
+        $xml = $this->_createXML()->addChild('prn:isdoc', '', $this->_namespace('prn'));
+
+        $this->_addElements($xml, $this->_elements, 'prn');
+
+        return $xml;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function _configureOptions(OptionsResolver $resolver)
+    {
+        // available options
+        $resolver->setDefined($this->_elements);
+
+        // validate / format options
+        $resolver->setRequired('includeToPdf');
+        $resolver->setNormalizer('includeToPdf', $resolver->getNormalizer('bool'));
+        
+        $resolver->setRequired('graphicNote');        
+        $resolver->setAllowedValues('graphicNote', ['topRight', 'topLeft', 'bottomRight', 'bottomLeft']);
+    }
+}

--- a/src/Pohoda/PrintRequest/Pdf.php
+++ b/src/Pohoda/PrintRequest/Pdf.php
@@ -16,7 +16,7 @@ use Riesenia\Pohoda\Common\OptionsResolver;
 class Pdf extends Agenda
 {
     /** @var string[] */
-    protected $_elements = ['fileName', 'binaryData'];
+    protected $_elements = ['fileName', 'binaryData', 'isdoc'];
 
     /**
      * {@inheritdoc}
@@ -26,6 +26,11 @@ class Pdf extends Agenda
         // process report
         if (isset($data['binaryData'])) {
             $data['binaryData'] = new BinaryData($data['binaryData'], $ico, $resolveOptions);
+        }
+
+        // process report
+        if (isset($data['isdoc'])) {
+            $data['isdoc'] = new Isdoc($data['isdoc'], $ico, $resolveOptions);
         }
       
         parent::__construct($data, $ico, $resolveOptions);

--- a/src/Pohoda/PrintRequest/Pdf.php
+++ b/src/Pohoda/PrintRequest/Pdf.php
@@ -16,8 +16,21 @@ use Riesenia\Pohoda\Common\OptionsResolver;
 class Pdf extends Agenda
 {
     /** @var string[] */
-    protected $_elements = ['fileName'];
+    protected $_elements = ['fileName', 'binaryData'];
 
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(array $data, string $ico, bool $resolveOptions = true)
+    {
+        // process report
+        if (isset($data['binaryData'])) {
+            $data['binaryData'] = new BinaryData($data['binaryData'], $ico, $resolveOptions);
+        }
+      
+        parent::__construct($data, $ico, $resolveOptions);
+    }
+    
     /**
      * {@inheritdoc}
      */

--- a/src/Pohoda/PrintRequest/Pdf.php
+++ b/src/Pohoda/PrintRequest/Pdf.php
@@ -23,12 +23,10 @@ class Pdf extends Agenda
      */
     public function __construct(array $data, string $ico, bool $resolveOptions = true)
     {
-        // process report
         if (isset($data['binaryData'])) {
             $data['binaryData'] = new BinaryData($data['binaryData'], $ico, $resolveOptions);
         }
-
-        // process report
+        
         if (isset($data['isdoc'])) {
             $data['isdoc'] = new Isdoc($data['isdoc'], $ico, $resolveOptions);
         }


### PR DESCRIPTION
This pull request adds the ability to export printed documents directly as binary data and optionally embed ISDOC into the resulting PDF.

Example usage: 

```php
$data = [
   'printerSettings' => [
      'pdf' => [
          'fileName' => 'C:\...\invoice.pdf', // still required
          'binaryData' => [
              'responseXml' => true,
              'removeFile' => true
          ],
          'isdoc' => [
              'includeToPdf' => true,
              'graphicNote' => 'topRight'
          ]
      ]
   ]
];

$request = $pohoda->createPrintRequest($data);
```