### PR TITLE
Add support for `correctionMOSS`

### DIFF
--- a/spec/Pohoda/InvoiceSpec.php
+++ b/spec/Pohoda/InvoiceSpec.php
@@ -167,7 +167,7 @@ class InvoiceSpec extends ObjectBehavior
         $this->beConstructedWith([
             'invoiceType' => 'issuedCreditNotice',
             'dateTaxOriginalDocumentMOSS' => '2026-03-31',
-            'correctionMOSS' => true,
+            'correctionMOSS' => true
         ], '123');
 
         $this->getXML()->asXML()->shouldReturn('<inv:invoice version="2.0"><inv:invoiceHeader><inv:invoiceType>issuedCreditNotice</inv:invoiceType><inv:dateTaxOriginalDocumentMOSS>2026-03-31</inv:dateTaxOriginalDocumentMOSS><inv:correctionMOSS>true</inv:correctionMOSS></inv:invoiceHeader></inv:invoice>');

--- a/spec/Pohoda/InvoiceSpec.php
+++ b/spec/Pohoda/InvoiceSpec.php
@@ -162,6 +162,17 @@ class InvoiceSpec extends ObjectBehavior
         $this->getXML()->asXML()->shouldReturn('<inv:invoice version="2.0"><inv:links><typ:link><typ:sourceAgenda>receivedOrder</typ:sourceAgenda><typ:sourceDocument><typ:number>142100003</typ:number></typ:sourceDocument></typ:link></inv:links><inv:invoiceHeader>' . $this->_defaultHeader() . '</inv:invoiceHeader></inv:invoice>');
     }
 
+    public function it_can_set_correction_moss()
+    {
+        $this->beConstructedWith([
+            'invoiceType' => 'issuedCreditNotice',
+            'dateTaxOriginalDocumentMOSS' => '2026-03-31',
+            'correctionMOSS' => true,
+        ], '123');
+
+        $this->getXML()->asXML()->shouldReturn('<inv:invoice version="2.0"><inv:invoiceHeader><inv:invoiceType>issuedCreditNotice</inv:invoiceType><inv:dateTaxOriginalDocumentMOSS>2026-03-31</inv:dateTaxOriginalDocumentMOSS><inv:correctionMOSS>true</inv:correctionMOSS></inv:invoiceHeader></inv:invoice>');
+    }
+
     protected function _defaultHeader()
     {
         return '<inv:invoiceType>issuedInvoice</inv:invoiceType><inv:date>2015-01-10</inv:date><inv:partnerIdentity><typ:id>25</typ:id></inv:partnerIdentity><inv:myIdentity><typ:address><typ:name>NAME</typ:name><typ:ico>123</typ:ico></typ:address></inv:myIdentity><inv:intNote>Note</inv:intNote>';

--- a/src/Pohoda/Invoice/Header.php
+++ b/src/Pohoda/Invoice/Header.php
@@ -18,7 +18,7 @@ class Header extends DocumentHeader
     protected $_refElements = ['extId', 'number', 'accounting', 'classificationVAT', 'classificationKVDPH', 'order', 'paymentType', 'priceLevel', 'account', 'paymentAccount', 'centre', 'activity', 'contract', 'regVATinEU', 'MOSS', 'evidentiaryResourcesMOSS', 'carrier'];
 
     /** @var string[] */
-    protected $_elements = ['extId', 'invoiceType', 'number', 'symVar', 'originalDocument', 'originalDocumentNumber', 'symPar', 'date', 'dateTax', 'dateAccounting', 'dateKHDPH', 'dateDue', 'dateApplicationVAT', 'dateDelivery', 'accounting', 'classificationVAT', 'classificationKVDPH', 'numberKHDPH', 'text', 'partnerIdentity', 'myIdentity', 'order', 'numberOrder', 'dateOrder', 'paymentType', 'priceLevel', 'account', 'symConst', 'symSpec', 'paymentAccount', 'paymentTerminal', 'centre', 'activity', 'contract', 'regVATinEU', 'MOSS', 'evidentiaryResourcesMOSS', 'accountingPeriodMOSS', 'dateTaxOriginalDocumentMOSS', 'note', 'carrier', 'intNote'];
+    protected $_elements = ['extId', 'invoiceType', 'number', 'symVar', 'originalDocument', 'originalDocumentNumber', 'symPar', 'date', 'dateTax', 'dateAccounting', 'dateKHDPH', 'dateDue', 'dateApplicationVAT', 'dateDelivery', 'accounting', 'classificationVAT', 'classificationKVDPH', 'numberKHDPH', 'text', 'partnerIdentity', 'myIdentity', 'order', 'numberOrder', 'dateOrder', 'paymentType', 'priceLevel', 'account', 'symConst', 'symSpec', 'paymentAccount', 'paymentTerminal', 'centre', 'activity', 'contract', 'regVATinEU', 'MOSS', 'evidentiaryResourcesMOSS', 'accountingPeriodMOSS', 'dateTaxOriginalDocumentMOSS', 'correctionMOSS', 'carrier', 'note', 'intNote'];
 
     protected function _configureOptions(OptionsResolver $resolver)
     {
@@ -45,5 +45,6 @@ class Header extends DocumentHeader
         $resolver->setNormalizer('symSpec', $resolver->getNormalizer('string16'));
         $resolver->setNormalizer('paymentTerminal', $resolver->getNormalizer('bool'));
         $resolver->setNormalizer('dateTaxOriginalDocumentMOSS', $resolver->getNormalizer('date'));
+        $resolver->setNormalizer('correctionMOSS', $resolver->getNormalizer('bool'));
     }
 }


### PR DESCRIPTION
Z XSD
```XML
<xsd:element name="correctionMOSS" type="typ:boolean" minOccurs="0" default="false">
    <xsd:annotation>
        <xsd:documentation>Vykázat doklad jako opravu OSS (pouze pro opravné daňové doklady, dobropisy nebo vrubopisy).</xsd:documentation>
    </xsd:annotation>
</xsd:element>
```

pridaná podpora pre tento parameter.

Chcete, aby som pridal aj validáciu, či je hodnota parametra správna, podľa vstupných dát alebo toto necháme čisto na implementácií?