### PR TITLE
Add extId support to Bank/Header

### DIFF
--- a/spec/Pohoda/BankSpec.php
+++ b/spec/Pohoda/BankSpec.php
@@ -57,6 +57,21 @@ class BankSpec extends ObjectBehavior
         $this->getXML()->asXML()->shouldReturn('<bnk:bank version="2.0"><bnk:bankHeader>' . $this->_defaultHeader() . '</bnk:bankHeader><bnk:bankSummary><bnk:homeCurrency><typ:priceNone>500</typ:priceNone></bnk:homeCurrency></bnk:bankSummary></bnk:bank>');
     }
 
+    public function it_can_set_ext_id()
+    {
+        $this->beConstructedWith([
+            'extId' => [
+                'ids' => 'EXT-001',
+                'exSystemName' => 'TestApp'
+            ],
+            'bankType' => 'receipt',
+            'account' => 'KB',
+            'datePayment' => '2021-11-22',
+        ], '123');
+
+        $this->getXML()->asXML()->shouldReturn('<bnk:bank version="2.0"><bnk:bankHeader><bnk:extId><typ:ids>EXT-001</typ:ids><typ:exSystemName>TestApp</typ:exSystemName></bnk:extId><bnk:bankType>receipt</bnk:bankType><bnk:account><typ:ids>KB</typ:ids></bnk:account><bnk:datePayment>2021-11-22</bnk:datePayment></bnk:bankHeader></bnk:bank>');
+    }
+
     public function it_can_set_parameters()
     {
         $this->addParameter('IsOn', 'boolean', 'true');

--- a/src/Pohoda/Bank/Header.php
+++ b/src/Pohoda/Bank/Header.php
@@ -15,10 +15,10 @@ use Riesenia\Pohoda\Document\Header as DocumentHeader;
 class Header extends DocumentHeader
 {
     /** @var string[] */
-    protected $_refElements = ['account', 'accounting', 'classificationVAT', 'classificationKVDPH', 'paymentAccount', 'centre', 'activity', 'contract', 'MOSS', 'evidentiaryResourcesMOSS'];
+    protected $_refElements = ['extId', 'account', 'accounting', 'classificationVAT', 'classificationKVDPH', 'paymentAccount', 'centre', 'activity', 'contract', 'MOSS', 'evidentiaryResourcesMOSS'];
 
     /** @var string[] */
-    protected $_elements = ['bankType', 'account', 'statementNumber', 'symVar', 'dateStatement', 'datePayment', 'accounting', 'classificationVAT', 'classificationKVDPH', 'text', 'partnerIdentity', 'myIdentity', 'paymentAccount', 'symConst', 'symSpec', 'symPar', 'centre', 'activity', 'contract', 'MOSS', 'evidentiaryResourcesMOSS', 'accountingPeriodMOSS', 'note', 'intNote'];
+    protected $_elements = ['extId', 'bankType', 'account', 'statementNumber', 'symVar', 'dateStatement', 'datePayment', 'accounting', 'classificationVAT', 'classificationKVDPH', 'text', 'partnerIdentity', 'myIdentity', 'paymentAccount', 'symConst', 'symSpec', 'symPar', 'centre', 'activity', 'contract', 'MOSS', 'evidentiaryResourcesMOSS', 'accountingPeriodMOSS', 'note', 'intNote'];
 
     public function __construct(array $data, string $ico, bool $resolveOptions = true)
     {


### PR DESCRIPTION
## Summary

- Add `'extId'` to `$_refElements` and `$_elements` in `Bank/Header`, matching the pattern already used in `Invoice/Header` and `Order/Header`
- Add `it_can_set_ext_id()` phpspec test covering the expected XML output

## Motivation

The Pohoda XML schema (`bank.xsd`) defines `extId` of type `typ:extIdType` as an optional element of `bankHeaderType`, allowing external systems to tag bank records with their own identifiers for cross-referencing. Without this change, setting `extId` on a bank record throws:

```
The option "extId" does not exist. Defined options are: "MOSS", "account", ...
```

This is inconsistent with `Invoice/Header` and `Order/Header`, which already support `extId`.

## Use case

When importing bank transactions from an external API into Pohoda, `extId` is the standard mechanism to tag each record with the source transaction ID (`ids`) and the originating system name (`exSystemName`). Pohoda stores the mapping in a dedicated link table, enabling reliable cross-referencing between Pohoda and the external system.

## Expected XML output

```xml
<bnk:bank version="2.0">
  <bnk:bankHeader>
    <bnk:extId>
      <typ:ids>TXN-20250122-7170839739</typ:ids>
      <typ:exSystemName>pohoda-raiffeisenbank</typ:exSystemName>
    </bnk:extId>
    <bnk:bankType>receipt</bnk:bankType>
    ...
  </bnk:bankHeader>
</bnk:bank>
```

Closes #63